### PR TITLE
feat: Implement Report Detail Request System and Report Rejection

### DIFF
--- a/src/base/errors.cairo
+++ b/src/base/errors.cairo
@@ -3,4 +3,7 @@ pub mod Errors {
     pub const ONLY_OWNER_CAN_CLOSE: felt252 = 'Only owner can close project';
     pub const ONLY_OWNER_CAN_EDIT: felt252 = 'Only owner can edit project';
     pub const CAN_ONLY_CLOSE_AFTER_DEADLINE: felt252 = 'Can only close after deadline';
+    pub const ONLY_VALIDATOR: felt252 = 'Caller non validator';
+    pub const NOT_AUTHORIZED: felt252 = 'Not authorized';
+    pub const REQUEST_NOT_FOUND: felt252 = 'Request not found';
 }

--- a/src/base/types.cairo
+++ b/src/base/types.cairo
@@ -52,3 +52,13 @@ pub struct Validator {
     pub updated_at: u64,
     pub status: felt252,
 }
+
+#[derive(Drop, Clone, Serde, PartialEq, starknet::Store)]
+pub struct ReportDetailsRequest {
+    pub id: u256,
+    pub report_id: u256,
+    pub requester: ContractAddress,
+    pub details: ByteArray,
+    pub requested_at: u64,
+    pub is_completed: bool,
+}

--- a/src/interfaces/IFortichain.cairo
+++ b/src/interfaces/IFortichain.cairo
@@ -1,5 +1,5 @@
 use starknet::ContractAddress;
-use crate::base::types::{Escrow, Project, Report, Validator};
+use crate::base::types::{Escrow, Project, Report, ReportDetailsRequest, Validator};
 
 #[starknet::interface]
 pub trait IFortichain<TContractState> {
@@ -53,6 +53,28 @@ pub trait IFortichain<TContractState> {
     fn get_contributor_paid_status(
         ref self: TContractState, project_id: u256, submitter_address: ContractAddress,
     ) -> bool;
+
+    fn provide_more_details(ref self: TContractState, report_id: u256, details: ByteArray);
+
+    fn get_more_details_requests(
+        self: @TContractState, report_id: u256,
+    ) -> Span<ReportDetailsRequest>;
+
+    fn get_request_by_id(self: @TContractState, request_id: u256) -> ReportDetailsRequest;
+
+    fn get_more_details_request_count(self: @TContractState) -> u256;
+
+    fn mark_request_as_completed(ref self: TContractState, request_id: u256);
+
+    fn get_request_ids_for_report(self: @TContractState, report_id: u256) -> Span<u256>;
+
+    fn get_requests_by_requester(self: @TContractState) -> Span<ReportDetailsRequest>;
+
+    fn get_pending_requests_for_report(
+        self: @TContractState, report_id: u256,
+    ) -> Span<ReportDetailsRequest>;
+
+    fn reject_report(ref self: TContractState, report_id: u256);
 
     // --- Role Management & Validators ---
     fn set_role(


### PR DESCRIPTION
## Summary
Implemented `provideMoreDetails()` and `rejectReport()` functions with an efficient storage system for managing report detail requests.

## Key Features

- `provide_more_details()`: Enables researchers to provide additional information when requested by validators.
- `reject_report()`: Allows validators to directly reject submitted reports.
- Hybrid Storage Architecture: Optimized storage using Map + Vec approach for efficient querying.
- Comprehensive Access Control: Role-based permissions ensuring only validators can reject reports.
- Flexible Query System: Multiple `getter` functions for different data access patterns

## Testing Coverage

- [ ]  Comprehensive unit tests covering all scenarios
- [ ] Authorization and access control validation
- [ ] Edge cases and error handling
- [ ] Multi-user and cross-report functionality

## Functions Added

- `provide_more_details(report_id, details) `- Submit additional report information.
- `reject_report(report_id)` - Validator-only report rejection.
- `get_request_by_id(request_id)` - Direct request lookup.
- `get_more_details_requests(report_id)` - All requests for a report.
- `get_more_details_request_count()` - Get total count of all detail requests.
- `get_request_ids_for_report(report_id)` - Get array of request IDs for a report.
- `get_requests_by_requester()` - Get all requests made by the calling user.
- `get_pending_requests_for_report(report_id)` - Get incomplete requests for a report.
- `mark_request_as_completed(request_id)` - Track request fulfillment.

## Resolves
Closes #25 